### PR TITLE
Make tbmask a const function

### DIFF
--- a/fn-dsa-kgen/src/mp31.rs
+++ b/fn-dsa-kgen/src/mp31.rs
@@ -44,7 +44,7 @@
 
 // Return 0xFFFFFFFF if the top bit of x is 1, 0x00000000 otherwise.
 #[inline(always)]
-pub(crate) fn tbmask(x: u32) -> u32 {
+pub(crate) const fn tbmask(x: u32) -> u32 {
     ((x as i32) >> 31) as u32
 }
 


### PR DESCRIPTION
Hi there and thanks for this! Was experimenting a bit with `fn-dsa` and WASM and stumbled over a small oversight about `tbmask` not being a `const fn` when it's called by `lzcnt`. Cheers!