### PR TITLE
Bump rand_core to 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.82"
 
 [workspace.dependencies]
 # main dependencies
-rand_core = "0.6"
+rand_core = "0.9"
 zeroize = { version = "1.8", features = [ "zeroize_derive" ] }
 cpufeatures = "0.2"
 # dev-only dependencies

--- a/fn-dsa-comm/src/lib.rs
+++ b/fn-dsa-comm/src/lib.rs
@@ -19,7 +19,7 @@ pub mod shake;
 pub mod mq_avx2;
 
 // Re-export RNG traits to get a smooth dependency management.
-pub use rand_core::{CryptoRng, RngCore, Error as RngError};
+pub use rand_core::{CryptoRng, RngCore};
 
 /// Symbolic constant for FN-DSA with degree 512 (`logn = 9`).
 pub const FN_DSA_LOGN_512: u32 = 9;

--- a/fn-dsa-kgen/src/lib.rs
+++ b/fn-dsa-kgen/src/lib.rs
@@ -94,7 +94,7 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 pub use fn_dsa_comm::{
     sign_key_size, vrfy_key_size,
     FN_DSA_LOGN_512, FN_DSA_LOGN_1024,
-    CryptoRng, RngCore, RngError,
+    CryptoRng,
 };
 
 /// Key pair generator and temporary buffers.
@@ -117,7 +117,7 @@ pub trait KeyPairGenerator: Default {
     /// destination slices MUST have the exact size for their respective
     /// contents (see the `sign_key_size()` and `vrfy_key_size()`
     /// functions).
-    fn keygen<T: CryptoRng + RngCore>(&mut self,
+    fn keygen<T: CryptoRng>(&mut self,
         logn: u32, rng: &mut T, sign_key: &mut [u8], vrfy_key: &mut [u8]);
 }
 
@@ -136,7 +136,7 @@ macro_rules! kgen_impl {
 
     impl KeyPairGenerator for $typename {
 
-        fn keygen<T: CryptoRng + RngCore>(&mut self,
+        fn keygen<T: CryptoRng>(&mut self,
             logn: u32, rng: &mut T, sign_key: &mut [u8], vrfy_key: &mut [u8])
         {
             // Enforce minimum and maximum degree.
@@ -192,7 +192,7 @@ kgen_impl!(KeyPairGeneratorWeak, 2, 8);
 //   tmp_u16: 2*n
 //   tmp_u32: 6*n
 //   tmp_fxr: 2.5*n
-fn keygen_inner<T: CryptoRng + RngCore>(logn: u32, rng: &mut T,
+fn keygen_inner<T: CryptoRng>(logn: u32, rng: &mut T,
     sign_key: &mut [u8], vrfy_key: &mut [u8],
     tmp_i8: &mut [i8], tmp_u16: &mut [u16],
     tmp_u32: &mut [u32], tmp_fxr: &mut [fxp::FXR])

--- a/fn-dsa-sign/src/lib.rs
+++ b/fn-dsa-sign/src/lib.rs
@@ -84,7 +84,7 @@ pub use fn_dsa_comm::{
     HASH_ID_SHAKE256,
     DomainContext,
     DOMAIN_NONE,
-    CryptoRng, RngCore, RngError,
+    CryptoRng, RngCore,
 };
 
 /// Signing key handler and temporary buffers.
@@ -130,7 +130,7 @@ pub trait SigningKey: Sized {
     ///  - `sig`: the output slice for the generated signature; its size
     ///    MUST be exactly that expected for the key degree (see
     ///    `signature_size()`).
-    fn sign<T: CryptoRng + RngCore>(&mut self, rng: &mut T,
+    fn sign<T: CryptoRng>(&mut self, rng: &mut T,
         ctx: &DomainContext, id: &HashIdentifier, hv: &[u8], sig: &mut [u8]);
 }
 
@@ -249,7 +249,7 @@ macro_rules! sign_key_impl {
             vrfy_key.copy_from_slice(&self.vrfy_key[..len]);
         }
 
-        fn sign<T: CryptoRng + RngCore>(&mut self, rng: &mut T,
+        fn sign<T: CryptoRng>(&mut self, rng: &mut T,
             ctx: &DomainContext, id: &HashIdentifier, hv: &[u8], sig: &mut [u8])
         {
             let n = 1usize << self.logn;
@@ -438,7 +438,7 @@ fn compute_basis_inner(logn: u32,
 // 1/12289
 const INV_Q: flr::FLR = flr::FLR::scaled(6004310871091074, -66);
 
-fn sign_inner<T: CryptoRng + RngCore, P: PRNG>(logn: u32, rng: &mut T,
+fn sign_inner<T: CryptoRng, P: PRNG>(logn: u32, rng: &mut T,
     f: &[i8], g: &[i8], F: &[i8], G: &[i8], hashed_vrfy_key: &[u8],
     ctx: &DomainContext, id: &HashIdentifier, hv: &[u8], sig: &mut [u8],
     #[cfg(not(feature = "small_context"))]
@@ -1108,10 +1108,6 @@ pub(crate) mod tests {
         fn fill_bytes(&mut self, dest: &mut [u8]) {
             dest.copy_from_slice(&KAT_512_RND[self.0..(self.0 + dest.len())]);
             self.0 += dest.len();
-        }
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), RngError> {
-            self.fill_bytes(dest);
-            Ok(())
         }
     }
 

--- a/fn-dsa-sign/src/sign_avx2.rs
+++ b/fn-dsa-sign/src/sign_avx2.rs
@@ -136,7 +136,7 @@ pub(crate) unsafe fn compute_basis_avx2_inner(logn: u32,
 // This is a specialized version of sign_inner() (defined in the parent
 // module); it leverages AVX2 intrinsics to speed up operations.
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn sign_avx2_inner<T: CryptoRng + RngCore, P: PRNG>(
+pub(crate) unsafe fn sign_avx2_inner<T: CryptoRng, P: PRNG>(
     logn: u32, rng: &mut T,
     f: &[i8], g: &[i8], F: &[i8], G: &[i8], hashed_vrfy_key: &[u8],
     ctx: &DomainContext, id: &HashIdentifier, hv: &[u8], sig: &mut [u8],

--- a/fn-dsa/benches/util.rs
+++ b/fn-dsa/benches/util.rs
@@ -1,4 +1,4 @@
-use fn_dsa::{CryptoRng, RngCore, RngError};
+use fn_dsa::{CryptoRng, RngCore};
 use fn_dsa_comm::shake::{SHAKE256};
 
 #[cfg(target_arch = "x86")]
@@ -66,12 +66,6 @@ impl RngCore for FakeRNG {
     }
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.0.extract(dest);
-    }
-    fn try_fill_bytes(&mut self, dest: &mut [u8])
-        -> Result<(), RngError>
-    {
-        self.0.extract(dest);
-        Ok(())
     }
 }
 

--- a/fn-dsa/src/lib.rs
+++ b/fn-dsa/src/lib.rs
@@ -120,7 +120,7 @@ pub use fn_dsa_comm::{
     HASH_ID_SHAKE256,
     DomainContext,
     DOMAIN_NONE,
-    CryptoRng, RngCore, RngError,
+    CryptoRng, RngCore,
 };
 pub use fn_dsa_comm::shake::{SHAKE, SHAKE128, SHAKE256, SHA3_224, SHA3_256, SHA3_384, SHA3_512};
 pub use fn_dsa_kgen::{KeyPairGenerator, KeyPairGeneratorStandard, KeyPairGeneratorWeak, KeyPairGenerator512, KeyPairGenerator1024};
@@ -156,10 +156,6 @@ mod tests {
         fn next_u64(&mut self) -> u64 { unimplemented!(); }
         fn fill_bytes(&mut self, dest: &mut [u8]) {
             self.0.extract(dest);
-        }
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), RngError> {
-            self.fill_bytes(dest);
-            Ok(())
         }
     }
 
@@ -198,10 +194,6 @@ mod tests {
                 j += clen;
             }
             self.ptr = ptr;
-        }
-        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), RngError> {
-            self.fill_bytes(dest);
-            Ok(())
         }
     }
 


### PR DESCRIPTION
Hi there,

The greater Rust ecosystem is slowly moving to use a more recent version of the `rand`(`_core`) crates, and I was hit by a version incompatibility in a project of mine that I was updating. So I thought I'd submit a patch. As far as I can tell this is the smallest change necessary to make `fn-dsa`(`-*`) work with `rand_core` 0.9.x. No functionality was removed, the `try_*` methods were moved to their own `TryRngCore` trait which isn't necessary to implement or use in your project.

Hope this helps!